### PR TITLE
implement Durable Object hibernatable accept/callback

### DIFF
--- a/worker-sys/src/types/durable_object/state.rs
+++ b/worker-sys/src/types/durable_object/state.rs
@@ -19,10 +19,10 @@ extern "C" {
     #[wasm_bindgen(method, js_name=acceptWebSocket)]
     pub fn accept_websocket(this: &DurableObjectState, ws: &web_sys::WebSocket, tags: &js_sys::Object);
 
-    /* not implemented yet.
     #[wasm_bindgen(method, js_name=getWebSockets)]
-    pub fn get_websockets(this: &DurableObjectState, tag: js_sys::Object) -> js_sys::Object;
+    pub fn get_websockets(this: &DurableObjectState, tag: wasm_bindgen::JsValue) -> wasm_bindgen::JsValue;
 
+    /* not implemented yet.
     #[wasm_bindgen(extends=js_sys::Object)]
     pub type WebSocketRequestResponsePair;
 

--- a/worker-sys/src/types/durable_object/state.rs
+++ b/worker-sys/src/types/durable_object/state.rs
@@ -15,4 +15,18 @@ extern "C" {
 
     #[wasm_bindgen(method, js_name=waitUntil)]
     pub fn wait_until(this: &DurableObjectState, promise: &js_sys::Promise);
+
+    #[wasm_bindgen(method, js_name=acceptWebSocket)]
+    pub fn accept_websocket(this: &DurableObjectState, ws: &web_sys::WebSocket, tags: &js_sys::Object);
+
+    /* not implemented yet.
+    #[wasm_bindgen(method, js_name=getWebSockets)]
+    pub fn get_websockets(this: &DurableObjectState, tag: js_sys::Object) -> js_sys::Object;
+
+    #[wasm_bindgen(extends=js_sys::Object)]
+    pub type WebSocketRequestResponsePair;
+
+    #[wasm_bindgen(method, js_name=setWebSocketAutoResponse)]
+    pub fn set_websocket_auto_response(this: &DurableObjectState, request_response: WebSocketRequestResponsePair);
+    */
 }

--- a/worker/src/durable.rs
+++ b/worker/src/durable.rs
@@ -218,6 +218,28 @@ impl State {
         self.inner.accept_websocket(websocket.as_ref(), &js_tags)
     }
 
+    // FIXME: maybe this should be two functions? One with a tag and one without?
+    pub fn get_websockets(&self, tag: Option<&str>) -> Vec<WebSocket> {
+        let js_tag: JsValue = match tag {
+            Some(s) => s.into(),
+            None => JsValue::UNDEFINED,
+        };
+
+        let websockets = self.inner.get_websockets(js_tag);
+        let websockets: js_sys::Array = websockets
+            .dyn_into()
+            .expect("get_websockets returned wrong type");
+        websockets
+            .iter()
+            .map(|ws| {
+                let ws: web_sys::WebSocket = ws
+                    .dyn_into()
+                    .expect("get_websockets returned non-WebSocket value");
+                WebSocket::from(ws)
+            })
+            .collect()
+    }
+
     // needs to be accessed by the `durable_object` macro in a conversion step
     pub fn _inner(self) -> DurableObjectState {
         self.inner


### PR DESCRIPTION
This is part of the "hibernatable" websocket interface. So far the parts implemented are:

- `State::accept_websocket` (`acceptWebSocket` in JS)
- `DurableObject::websocket_message` (callback for incoming messages)
- `WebSocketIncomingMessage` (an ad-hoc enum for incoming String/Binary messages)

It's incomplete, but I have tested it locally and on Cloudflare, and it seems to work so far.

If you want to chat more about doing a community fork, maybe enable github issues or discussions?